### PR TITLE
Feature material shoppinglist relationship

### DIFF
--- a/src/main/java/com/pegazuls/aerodesign/PegStock/controllers/api/ShoppingController.java
+++ b/src/main/java/com/pegazuls/aerodesign/PegStock/controllers/api/ShoppingController.java
@@ -1,7 +1,6 @@
 package com.pegazuls.aerodesign.PegStock.controllers.api;
 
 import com.pegazuls.aerodesign.PegStock.model.dto.shopping_list.DTOShoppingDetails;
-import com.pegazuls.aerodesign.PegStock.model.dto.shopping_list.DTOShoppingSummary;
 import com.pegazuls.aerodesign.PegStock.model.entities.ShoppingList;
 import com.pegazuls.aerodesign.PegStock.service.ShoppingListService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -115,5 +114,17 @@ public class ShoppingController {
     public ResponseEntity<DTOShoppingDetails> getMostExpensive(){
         DTOShoppingDetails shoppingList = shoppingService.findMostExpensive();
         return shoppingList == null ? ResponseEntity.noContent().build() : ResponseEntity.ok(shoppingList);
+    }
+
+    @PostMapping("/{id}/purchase")
+    @SecurityRequirement(name = "bearer-key")
+    @Operation(summary = "Adicionar item da lista de compras ao estoque", description = "Adiciona a quantidade do item da lista de compras ao material existente no estoque.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Item adicionado ao estoque com sucesso."),
+            @ApiResponse(responseCode = "404", description = "Item da lista de compras ou material não encontrado.")
+    })
+    public ResponseEntity<?> purchaseItem(@PathVariable Long id) {
+        shoppingService.purchaseItem(id);
+        return ResponseEntity.ok("Item adicionado ao estoque com sucesso.");
     }
 }

--- a/src/main/java/com/pegazuls/aerodesign/PegStock/infra/validation/material/ValidationQuantityMaterial.java
+++ b/src/main/java/com/pegazuls/aerodesign/PegStock/infra/validation/material/ValidationQuantityMaterial.java
@@ -10,7 +10,7 @@ public class ValidationQuantityMaterial implements ValidationMaterial {
     @Override
     public void validate(Material material) {
         // Verify if the quantity is valid
-        if(material.getQuantity() <= 0){
+        if(material.getQuantity() < 0){
             throw new ValidationException("Quantidade inválida");
         }
     }

--- a/src/main/java/com/pegazuls/aerodesign/PegStock/model/entities/ShoppingList.java
+++ b/src/main/java/com/pegazuls/aerodesign/PegStock/model/entities/ShoppingList.java
@@ -43,6 +43,11 @@ public class ShoppingList {
 
     private Double totalValue;
 
+    @ManyToOne
+    @JoinColumn(name = "material_cod")
+    private Material material;
+
+
     public ShoppingList(DTOShoppingDetails dtoShoppingList) {
         this.cod = dtoShoppingList.cod();
         this.productName = dtoShoppingList.name();

--- a/src/main/java/com/pegazuls/aerodesign/PegStock/repository/MaterialRepository.java
+++ b/src/main/java/com/pegazuls/aerodesign/PegStock/repository/MaterialRepository.java
@@ -23,4 +23,6 @@ public interface MaterialRepository extends JpaRepository<Material, Long> {
     // return the most consumed material
     Material findFirstByOrderByConsumerQuantityDesc();
 
+    Material findByName(String name);
+
 }

--- a/src/main/java/com/pegazuls/aerodesign/PegStock/service/ShoppingListService.java
+++ b/src/main/java/com/pegazuls/aerodesign/PegStock/service/ShoppingListService.java
@@ -2,8 +2,11 @@ package com.pegazuls.aerodesign.PegStock.service;
 
 import com.pegazuls.aerodesign.PegStock.infra.validation.shopping_list.ValidationCreateSL;
 import com.pegazuls.aerodesign.PegStock.model.dto.shopping_list.DTOShoppingDetails;
-import com.pegazuls.aerodesign.PegStock.model.dto.shopping_list.DTOShoppingSummary;
+import com.pegazuls.aerodesign.PegStock.model.entities.Material;
 import com.pegazuls.aerodesign.PegStock.model.entities.ShoppingList;
+import com.pegazuls.aerodesign.PegStock.model.enums.Box;
+import com.pegazuls.aerodesign.PegStock.model.enums.Category;
+import com.pegazuls.aerodesign.PegStock.repository.MaterialRepository;
 import com.pegazuls.aerodesign.PegStock.repository.ShoppingListRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -22,6 +25,12 @@ public class ShoppingListService {
     private ShoppingListRepository repository;
 
     @Autowired
+    private MaterialRepository materialRepository;
+
+    @Autowired
+    private MaterialService materialService;
+
+    @Autowired
     private List<ValidationCreateSL> validations;
 
     @Transactional
@@ -29,7 +38,34 @@ public class ShoppingListService {
         validations.forEach(v -> v.validate(shoppingList));
         shoppingList.setTotalValue(shoppingList.getPrice() * shoppingList.getQuantity());
         shoppingList.setDate(LocalDate.now());
+
+        Material material = materialRepository.findByName(shoppingList.getProductName());
+
+        if (material == null) {
+            Material newMaterial = new Material();
+            newMaterial.setName(shoppingList.getProductName());
+            newMaterial.setDescription("Material criado automaticamente");
+            newMaterial.setQuantity(0); 
+            newMaterial.setCategory(Category.CONSUMIVEL); 
+            newMaterial.setBox(Box.OUTROS); 
+            material = materialService.create(newMaterial);
+        }
+
+        shoppingList.setMaterial(material);
         return repository.save(shoppingList);
+    }
+
+    @Transactional
+    public void purchaseItem(Long shoppingListId) {
+        ShoppingList shoppingList = repository.findById(shoppingListId).orElse(null);
+        if (shoppingList != null) {
+            Material material = shoppingList.getMaterial();
+            if (material != null) {
+                material.setQuantity(material.getQuantity() + shoppingList.getQuantity());
+                materialService.update(material, material.getCod());
+            }
+            delete(shoppingListId);
+        }
     }
 
     public List<ShoppingList> findAll() {

--- a/src/main/resources/db/migration/V5__alter_tb_shopping_list_add_material_id.sql
+++ b/src/main/resources/db/migration/V5__alter_tb_shopping_list_add_material_id.sql
@@ -1,0 +1,4 @@
+ALTER TABLE tb_shopping_list ADD COLUMN material_cod BIGINT;
+ALTER TABLE tb_shopping_list
+ADD CONSTRAINT fk_shopping_list_material
+FOREIGN KEY (material_cod) REFERENCES tb_material(cod);


### PR DESCRIPTION

* Added a new `purchaseItem` endpoint in `ShoppingController` to allow users to add shopping list items to inventory
* Updated the `ShoppingList` entity to include a `Material` association using a `@ManyToOne` relationship.
* Added a database migration script to include a `material_cod` column in the `tb_shopping_list` table and establish a foreign key relationship with `tb_material`.
* Modified the `ShoppingListService` to automatically create a new `Material` if one does not exist when creating a shopping list item. The service now also updates material quantities when an item is purchased.
* Updated `ValidationQuantityMaterial` to allow zero as a valid material quantity
* Added a `findByName` method to `MaterialRepository`